### PR TITLE
[3.x] Add information on pipelines for pint & phpstan

### DIFF
--- a/src/3.x/configuration.md
+++ b/src/3.x/configuration.md
@@ -122,31 +122,3 @@ EARLY_HINTS_ENABLED=false
 ::: tip
 You should [preload your custom fonts](https://web.dev/articles/codelab-preload-web-fonts) if they're used during the initial render.
 :::
-
-## Pipelines
-
-Rapidez comes with PHPStan for static analysis (`composer analyse`) and Pint (`composer style` and `composer fix-style`) for code style analysis installed by default. These can be used in automated pipelines to help keep code quality under control.
-
-### GitHub actions
-
-The `rapidez/rapidez` repository contains an example PHPStan workflow [here](https://github.com/rapidez/rapidez/blob/master/.github/workflows/analyse.yml). Replace `composer analyse` with `composer style` to run Pint.
-
-### Bitbucket pipelines
-
-If you're using Bitbucket you can set up these pipelines with a php docker container. A pipeline step to run PHPStan could look something like this:
-
-```yaml
-    - step: &analyse
-        name: Static analysis
-        image:
-          name: $DOCKER_IMAGE
-          username: $DOCKER_USERNAME
-          password: $DOCKER_PASSWORD
-        caches:
-          - composer
-        script:
-          - composer install
-          - cp .env.example .env
-          - php artisan key:generate
-          - composer analyse
-```

--- a/src/3.x/configuration.md
+++ b/src/3.x/configuration.md
@@ -122,3 +122,31 @@ EARLY_HINTS_ENABLED=false
 ::: tip
 You should [preload your custom fonts](https://web.dev/articles/codelab-preload-web-fonts) if they're used during the initial render.
 :::
+
+## Pipelines
+
+Rapidez comes with PHPStan for static analysis (`composer analyse`) and Pint (`composer style` and `composer fix-style`) for code style analysis installed by default. These can be used in automated pipelines to help keep code quality under control.
+
+### GitHub actions
+
+The `rapidez/rapidez` repository contains an example PHPStan workflow [here](https://github.com/rapidez/rapidez/blob/master/.github/workflows/analyse.yml). Replace `composer analyse` with `composer style` to run Pint.
+
+### Bitbucket pipelines
+
+If you're using Bitbucket you can set up these pipelines with a php docker container. A pipeline step to run PHPStan could look something like this:
+
+```yaml
+    - step: &analyse
+        name: Static analysis
+        image:
+          name: $DOCKER_IMAGE
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+        caches:
+          - composer
+        script:
+          - composer install
+          - cp .env.example .env
+          - php artisan key:generate
+          - composer analyse
+```

--- a/src/3.x/testing.md
+++ b/src/3.x/testing.md
@@ -64,10 +64,7 @@ If you're using Bitbucket you can set up these pipelines with a php docker conta
 ```yaml
     - step: &analyse
         name: Static analysis
-        image:
-          name: $DOCKER_IMAGE
-          username: $DOCKER_USERNAME
-          password: $DOCKER_PASSWORD
+        image: ghcr.io/justbetter/docker-ci-php-node:1-22.04-8.3-22
         caches:
           - composer
         script:

--- a/src/3.x/testing.md
+++ b/src/3.x/testing.md
@@ -48,3 +48,31 @@ $browser->waitUntilTrueForDuration('true', 120, 0.5);
 ## Continuous Integration
 
 If you would like to run the tests with a CI tool like Bitbucket Pipelines or Github Actions, you need to ensure that there is a Magento environment that Rapidez can work with. You could use a test environment for this, so you don't have to set up a Magento environment in Docker. However, you will need to create an SSH tunnel for the database connection, and for every run, orders will be created. If you have made it this far and you're interested, [ask us on Slack](https://rapidez.io/slack)!
+
+## Static analysis
+
+Rapidez comes with PHPStan for static analysis (`composer analyse`) and Pint (`composer style` and `composer fix-style`) for code style analysis installed by default. These can be used in automated pipelines to help keep code quality under control.
+
+### GitHub actions
+
+The `rapidez/rapidez` repository contains an example PHPStan workflow [here](https://github.com/rapidez/rapidez/blob/master/.github/workflows/analyse.yml). Replace `composer analyse` with `composer style` to run Pint.
+
+### Bitbucket pipelines
+
+If you're using Bitbucket you can set up these pipelines with a php docker container. A pipeline step to run PHPStan could look something like this:
+
+```yaml
+    - step: &analyse
+        name: Static analysis
+        image:
+          name: $DOCKER_IMAGE
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+        caches:
+          - composer
+        script:
+          - composer install
+          - cp .env.example .env
+          - php artisan key:generate
+          - composer analyse
+```


### PR DESCRIPTION
I wasn't sure how to structure this properly---I've added a bit of information about phpstan/pint and then added a little bit of example code for github actions (just pointed to rapidez/rapidez) and for bitbucket pipelines (keeping it generic).

If we end up removing the action from rapidez/rapidez, however, then that part will have to change a bit.