### PR TITLE
[4.x] Update the upgrade docs

### DIFF
--- a/src/4.x/configuration.md
+++ b/src/4.x/configuration.md
@@ -100,4 +100,17 @@ EARLY_HINTS_ENABLED=false
 
 ::: tip
 You should [preload your custom fonts](https://web.dev/articles/codelab-preload-web-fonts) if they're used during the initial render.
-:::
+
+## Store-specific values
+
+You can override any Rapidez config value with a store-specific variant by creating a store-specific config file to override them. For example, if you want to have a store with store_code `secondstore` and make it use a different theme folder, you can make a new config file under `config/rapidez/stores/secondstore/frontend.php` like this:
+
+```php
+<?php
+
+return [
+    'theme' => resource_path('themes/secondstore'),
+];
+```
+
+Note that you only need to add the values that you actually want to overwrite. Everything else will be taken from the default configuration.

--- a/src/4.x/configuration.md
+++ b/src/4.x/configuration.md
@@ -100,17 +100,3 @@ EARLY_HINTS_ENABLED=false
 
 ::: tip
 You should [preload your custom fonts](https://web.dev/articles/codelab-preload-web-fonts) if they're used during the initial render.
-
-## Store-specific values
-
-You can override any Rapidez config value with a store-specific variant by creating a store-specific config file to override them. For example, if you want to have a store with store_code `secondstore` and make it use a different theme folder, you can make a new config file under `config/rapidez/stores/secondstore/frontend.php` like this:
-
-```php
-<?php
-
-return [
-    'theme' => resource_path('themes/secondstore'),
-];
-```
-
-Note that you only need to add the values that you actually want to overwrite. Everything else will be taken from the default configuration.

--- a/src/4.x/configuration.md
+++ b/src/4.x/configuration.md
@@ -100,3 +100,4 @@ EARLY_HINTS_ENABLED=false
 
 ::: tip
 You should [preload your custom fonts](https://web.dev/articles/codelab-preload-web-fonts) if they're used during the initial render.
+:::

--- a/src/4.x/upgrading.md
+++ b/src/4.x/upgrading.md
@@ -54,14 +54,6 @@ You will also have to replace `ELASTICSEARCH_PREFIX` with `SCOUT_PREFIX`:
 +  SCOUT_PREFIX="your_prefix_here"
 ```
 
-### `providers.php` changes
-
-You need to add the Scout Elasticsearch provider to your providers file:
-
-```php
-Matchish\ScoutElasticSearch\ElasticSearchServiceProvider::class,
-```
-
 ## Frontend changes
 
 ### Dependencies

--- a/src/4.x/upgrading.md
+++ b/src/4.x/upgrading.md
@@ -104,4 +104,4 @@ return [
 ];
 ```
 
-With this refactor, you can use this method override *any* Rapidez config value with a store-specific variant.
+With this refactor, you can use this method override *any* Rapidez config value with a store-specific variant. See also [the documentation for this functionality](configuration.md#multistore).

--- a/src/4.x/upgrading.md
+++ b/src/4.x/upgrading.md
@@ -31,20 +31,21 @@ composer outdated
 
 ### `.env` changes
 
-We changed the product index to use [Laravel Scout](https://github.com/laravel/scout), to support [ElasticSearch](https://github.com/elastic/elasticsearch) as driver we need an [elasticsearch driver](https://github.com/matchish/laravel-scout-elasticsearch) and with this change we don't need [mailerlite/laravel-elasticsearch](https://github.com/mailerlite/laravel-elasticsearch) anymore. The `.env` configs are different so you need to change:
+We changed the product index to use [Laravel Scout](https://github.com/laravel/scout), to support [ElasticSearch](https://github.com/elastic/elasticsearch) as driver we need an [elasticsearch driver](https://github.com/matchish/laravel-scout-elasticsearch) and with this change we don't need [mailerlite/laravel-elasticsearch](https://github.com/mailerlite/laravel-elasticsearch) anymore. To configure scout, you need to add the following `.env` lines:
 
 ```dotenv
-ELASTICSEARCH_HOST=localhost
-ELASTICSEARCH_PORT=9200
-ELASTICSEARCH_SCHEME=http
-ELASTICSEARCH_USER=
-ELASTICSEARCH_PASS=
+SCOUT_DRIVER=Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine
+SCOUT_PREFIX="your_prefix_here"
 ```
-To
-```dotenv
-ELASTICSEARCH_HOST=http://localhost:9200
-ELASTICSEARCH_USER=
-ELASTICSEARCH_PASSWORD=
+
+Note that `ELASTICSEARCH_PREFIX` has been replaced with `SCOUT_PREFIX`.
+
+### `providers.php` changes
+
+You need to add the Scout Elasticsearch provider to your providers file:
+
+```php
+Matchish\ScoutElasticSearch\ElasticSearchServiceProvider::class,
 ```
 
 ## Frontend changes

--- a/src/4.x/upgrading.md
+++ b/src/4.x/upgrading.md
@@ -83,3 +83,33 @@ yarn build
 :::tip
 We recommend to double check all frontend dependencies with `yarn outdated`. But keep in mind that Rapidez doesn't support Vue 3 yet.
 :::
+
+## Config refactor
+
+### Store-specific values
+
+With the config refactor comes a rework of how store-specific config values get defined. You will have to change the `checkout_steps` and `themes` values in `frontend.php` to reflect this:
+
+```diff
+'checkout_steps' => [
+-  'default' => ['login', 'credentials', 'payment'],
++  'login', 'credentials', 'payment',
+],
+...
+-'themes' => [
+-   'default' => resource_path('themes/default'),
+-],
++'theme' => resource_path('themes/default'),
+```
+
+Any store-specific values have been moved to store-specific config files. For example, if you had a store with store_code `secondstore` with a different theme folder, you need to make a new config file under `config/rapidez/stores/secondstore/frontend.php` like this:
+
+```php
+<?php
+
+return [
+    'theme' => resource_path('themes/secondstore'),
+];
+```
+
+With this refactor, you can use this method override *any* Rapidez config value with a store-specific variant.

--- a/src/4.x/upgrading.md
+++ b/src/4.x/upgrading.md
@@ -47,14 +47,12 @@ ELASTICSEARCH_USER=
 ELASTICSEARCH_PASSWORD=
 ```
 
-You will also have to add the following lines:
+You will also have to replace `ELASTICSEARCH_PREFIX` with `SCOUT_PREFIX`:
 
-```dotenv
-SCOUT_DRIVER=Matchish\ScoutElasticSearch\Engines\ElasticSearchEngine
-SCOUT_PREFIX="your_prefix_here"
+```diff
+-  ELASTICSEARCH_PREFIX="your_prefix_here"
++  SCOUT_PREFIX="your_prefix_here"
 ```
-
-Note that `ELASTICSEARCH_PREFIX` has been replaced with `SCOUT_PREFIX`.
 
 ### `providers.php` changes
 


### PR DESCRIPTION
Renamed .env vars can be removed after the latest update to the ES driver.

I've also added the 2 remaining necessary steps required, see also: https://github.com/rapidez/rapidez/pull/96