### PR TITLE
[3.x] Add vueuse integrations to upgrade docs

### DIFF
--- a/src/3.x/upgrading.md
+++ b/src/3.x/upgrading.md
@@ -61,7 +61,7 @@ class Authenticate extends Middleware
 
 1. **Install**
 ```bash
-yarn add -D graphql graphql-tag universal-cookie "graphql-combine-query@indykoning/graphql-combine-query#feature/add-allowed-duplicates"
+yarn add -D @vueuse/integrations graphql graphql-tag universal-cookie "graphql-combine-query@indykoning/graphql-combine-query#feature/add-allowed-duplicates"
 ```
 2. **Build**
 ```bash


### PR DESCRIPTION
Required for `useCookies` which is part of the core. This package was also added in this version.