### PR TITLE
[3.x] Add information about static caching excludes for checkout pages

### DIFF
--- a/src/2.x/packages/statamic.md
+++ b/src/2.x/packages/statamic.md
@@ -273,6 +273,24 @@ We recommend to schedule this command in `routes/console.php` to invalidate peri
 Schedule::command('rapidez-statamic:invalidate-cache')->everyFifteenMinutes();
 ```
 
+You should also set up exclusions for a few routes in your `config/statamic/static_caching.php` config file:
+
+```php
+'exclude' => [
+    'exclude' => [
+        'class' => null,
+        'urls' => [
+            '/login',
+            '/register'
+            '/checkout',
+            '/checkout/*',
+        ],
+    ],
+]
+```
+
+You should add any other custom routes here that you don't want cached. Most importantly, any routes that will differ based on login state or cart state.
+
 ## Upgrading
 
 ### From 2.x to 3.x

--- a/src/3.x/packages/statamic.md
+++ b/src/3.x/packages/statamic.md
@@ -257,6 +257,24 @@ We recommend to schedule this command in `routes/console.php` to invalidate peri
 Schedule::command('rapidez-statamic:invalidate-cache')->everyFifteenMinutes();
 ```
 
+You should also set up exclusions for a few routes in your `config/statamic/static_caching.php` config file:
+
+```php
+'exclude' => [
+    'exclude' => [
+        'class' => null,
+        'urls' => [
+            '/login',
+            '/register'
+            '/checkout',
+            '/checkout/*',
+        ],
+    ],
+]
+```
+
+You should add any other custom routes here that you don't want cached. Most importantly, any routes that will differ based on login state or cart state.
+
 ## Upgrading
 
 ### From 4.x to 5.x

--- a/src/3.x/upgrading.md
+++ b/src/3.x/upgrading.md
@@ -120,9 +120,6 @@ We moved everything to Laravel routes where previously this was handled with cus
 
 With these routes, you can "secure" them where previously this was checked on the frontend. When unauthorized, you were redirected away after the page load. This is now handled server-side. All checkout steps are secured with the `auth:magento-cart` middleware by default to validate the cart mask. To make this possible, the mask and customer token are moved from LocalStorage to Cookies.
 
-> [!NOTE]
-> These are new routes, so they will need to be excluded from static caching in Statamic if you have that enabled. This means you need to add `/checkout/*` to your `statamic.static_caching.exclude.urls` configuration.
-
 ### Onestep checkout
 
 In the `config/rapidez/frontend.php` config there is a `checkout_steps` option. Those steps link to Blade views within the `resources/views/checkout/pages` directory. To use the one step checkout just swap the default with the [`onestep`](https://github.com/rapidez/core/blob/master/resources/views/checkout/pages/onestep.blade.php) view:

--- a/src/3.x/upgrading.md
+++ b/src/3.x/upgrading.md
@@ -120,6 +120,9 @@ We moved everything to Laravel routes where previously this was handled with cus
 
 With these routes, you can "secure" them where previously this was checked on the frontend. When unauthorized, you were redirected away after the page load. This is now handled server-side. All checkout steps are secured with the `auth:magento-cart` middleware by default to validate the cart mask. To make this possible, the mask and customer token are moved from LocalStorage to Cookies.
 
+> [!NOTE]
+> These are new routes, so they will need to be excluded from static caching in Statamic if you have that enabled. This means you need to add `/checkout/*` to your `statamic.static_caching.exclude.urls` configuration.
+
 ### Onestep checkout
 
 In the `config/rapidez/frontend.php` config there is a `checkout_steps` option. Those steps link to Blade views within the `resources/views/checkout/pages` directory. To use the one step checkout just swap the default with the [`onestep`](https://github.com/rapidez/core/blob/master/resources/views/checkout/pages/onestep.blade.php) view:

--- a/src/4.x/packages/statamic.md
+++ b/src/4.x/packages/statamic.md
@@ -257,6 +257,24 @@ We recommend to schedule this command in `routes/console.php` to invalidate peri
 Schedule::command('rapidez-statamic:invalidate-cache')->everyFifteenMinutes();
 ```
 
+You should also set up exclusions for a few routes in your `config/statamic/static_caching.php` config file:
+
+```php
+'exclude' => [
+    'exclude' => [
+        'class' => null,
+        'urls' => [
+            '/login',
+            '/register'
+            '/checkout',
+            '/checkout/*',
+        ],
+    ],
+]
+```
+
+You should add any other custom routes here that you don't want cached. Most importantly, any routes that will differ based on login state or cart state.
+
 ## Indexing
 
 You can extend the `BaseEntry` model provided with this package to index your collection data into ElasticSearch. See the following example of a blog collection:


### PR DESCRIPTION
I'm not sure what documentation there is for setting up these exclude URLs to begin with. It's not mentioned [here](https://docs.rapidez.io/4.x/packages/statamic.html#static-caching) which means it's probably not mentioned anywhere 🤔